### PR TITLE
Add mistake counting to "show next stroke" hint button

### DIFF
--- a/Card Templates/Basic - Mandarin/Writing/Writing - English -> Mandarin - Front.html
+++ b/Card Templates/Basic - Mandarin/Writing/Writing - English -> Mandarin - Front.html
@@ -362,6 +362,7 @@ var Quiz = (function () {
   var _totalMistakes = 0;
   var _mistakesThisChar = 0;
   var _nextStrokeIndex = 0;
+  var _hintCountThisChar = 0;
   var _worstRating = null;
 
   function _makeGuard(capturedId) {
@@ -516,6 +517,7 @@ var Quiz = (function () {
     _currentIndex = charIndex;
     _mistakesThisChar = 0;
     _nextStrokeIndex = 0;
+    _hintCountThisChar = 0;
 
     var characters = _characters;
     var writer = _writers[charIndex];
@@ -754,10 +756,16 @@ var Quiz = (function () {
   function hintCurrentStroke() {
     var writer = _writers[_currentIndex];
     if (!writer) return;
-    if (_nextStrokeIndex === 0 && _currentIndex === 0) {
-      _weightedMistakeScore = _totalStrokeCount;
-      _updateRatingIndicator();
+    _hintCountThisChar++;
+    _mistakesThisChar++;
+    _totalMistakes++;
+    if (_hintCountThisChar <= 2) {
+      _weightedMistakeScore += 1 / (_nextStrokeIndex + 1);
+    } else {
+      _weightedMistakeScore += 1;
     }
+    _updateFeedback();
+    _updateRatingIndicator();
     writer.highlightStroke(_nextStrokeIndex);
   }
 

--- a/docs/adr/001-ankiconnect-for-template-deployment.md
+++ b/docs/adr/001-ankiconnect-for-template-deployment.md
@@ -1,0 +1,76 @@
+# ADR-001: Use AnkiConnect for Template Deployment
+
+## Status
+
+Proposed
+
+## Context
+
+We need a way to push card templates (front HTML, back HTML, CSS) from this repo
+into Anki programmatically. Currently this is done by hand: open Anki's template
+editor, select the card type, paste the HTML, repeat for every card and note type.
+
+Three approaches were considered:
+
+1. **AnkiConnect API** — An Anki add-on that exposes a local HTTP API on port
+   8765. Provides `updateModelTemplates`, `updateModelStyling`, `modelTemplates`,
+   `modelStyling`, and `exportPackage` endpoints.
+
+2. **Direct SQLite modification** — Anki stores note types in a SQLite database
+   (`collection.anki21`). We could modify the `notetypes` and `templates` tables
+   directly.
+
+3. **`.apkg` export/import** — Build a `.apkg` package with the updated templates
+   and import it into Anki.
+
+## Decision
+
+Use **AnkiConnect** (option 1).
+
+## Consequences
+
+### Positive
+
+- **Safe**: AnkiConnect goes through Anki's internal APIs, respecting undo
+  history, sync state, and schema migrations. Direct SQLite writes bypass all of
+  this.
+- **Read and write**: We can read current state (for backup and diff) and write
+  updates through the same API.
+- **Backup via API**: `exportPackage` can create `.apkg` backups before we push,
+  or we can snapshot all templates/CSS via the read endpoints.
+- **No file-locking issues**: Anki locks its SQLite database while running.
+  AnkiConnect works *because* Anki is running, not despite it.
+- **Well-established**: AnkiConnect has been maintained since 2016, is widely
+  used by automation tools, and is the de facto standard for programmatic Anki
+  interaction.
+- **Simple HTTP**: Plain JSON-over-HTTP on localhost. No special client library
+  required (though `yanki-connect` exists for typed usage).
+
+### Negative
+
+- **Requires Anki desktop running**: Cannot deploy from CI or headless
+  environments. This is acceptable — we only deploy from a development machine
+  where Anki is open.
+- **Add-on dependency**: If AnkiConnect stops being maintained, we'd need to find
+  an alternative. Risk is low given its long track record.
+- **No transactional deploy**: AnkiConnect processes one API call at a time. If
+  the script fails mid-deploy (e.g. after updating 3 of 5 templates), Anki will
+  be in a partially-updated state. Mitigated by: pre-deploy backup, fail-fast
+  behaviour, and restore script.
+
+### Why not direct SQLite?
+
+- Anki locks the DB while running — we'd need to close Anki first, defeating the
+  purpose of quick iteration.
+- Schema has changed across Anki versions (legacy JSON-in-column vs normalised
+  tables). We'd need to handle both.
+- Bypasses Anki's undo/sync infrastructure, risking data corruption.
+- No advantage over AnkiConnect for our use case.
+
+### Why not `.apkg` import?
+
+- `.apkg` import is designed for adding new notes, not updating templates on
+  existing notes. Importing a package with template changes can create duplicate
+  note types or fail to update existing ones.
+- Doesn't provide a read/diff capability.
+- More complex to construct than a simple HTTP call.

--- a/docs/adr/002-repo-file-structure-conventions.md
+++ b/docs/adr/002-repo-file-structure-conventions.md
@@ -1,0 +1,121 @@
+# ADR-002: Repo File Structure Conventions
+
+## Status
+
+Proposed
+
+## Context
+
+The four note type directories in `Card Templates/` have inconsistent structure:
+
+1. **Subdirectories vs flat**:
+   - `Basic - Mandarin/` uses numbered subdirectories (`1. Reading, Listening
+     and Speaking With Audio/`, `2. Reading Without Audio/`, `Writing/`)
+   - The other three note types are flat (all HTML files at root level)
+
+2. **CSS filename**:
+   - `Basic - Mandarin/` and `Basic - Mandarin Sentences/` use `style.css`
+   - `Basic - Mandarin Grammar/` and `Basic - Mandarin From Subtitles/` use
+     `styles.css`
+
+3. **HTML filename pattern**:
+   The card template name is encoded as `{Card Template Name} - Front.html` and
+   `{Card Template Name} - Back.html`. This pattern is consistent across all
+   four note types, but the card template names themselves vary in style:
+   - Most use `{Skill} {With|Without} Audio - {Direction}` format
+   - Sentences uses `Mandarin - {Skill}` format
+   - Grammar Quiz has no direction component
+
+These inconsistencies make it harder to write tooling that walks the tree
+reliably.
+
+## Decision
+
+### CSS filename: standardise on `style.css` (singular)
+
+Rename `styles.css` to `style.css` in Grammar and From Subtitles directories.
+Singular matches the Anki UI label ("Styling") and is already used by two of four
+note types.
+
+### Directory structure: flatten all note types
+
+Remove the numbered subdirectories in `Basic - Mandarin/`. All HTML files live
+directly under their note type directory, matching the other three.
+
+Rationale: the subdirectories add no information that isn't already in the
+filename. They complicate glob patterns and the deploy script's directory walker.
+The numbered prefixes (`1.`, `2.`) encoded a display order that Anki itself
+controls via template ordering, not filesystem position.
+
+### HTML filenames: do not rename
+
+Card template names in Anki are user-visible (shown in the card browser and
+template editor). Renaming them would require `modelTemplateRename` API calls
+and would change how cards appear in Anki's UI. The current names are descriptive
+and functional — the inconsistency between note types reflects genuine
+differences in card behaviour (Sentences cards don't have a direction because
+they're always Mandarin -> English).
+
+The deploy script will derive the card template name by stripping ` - Front.html`
+or ` - Back.html` from the filename. This works for all existing files.
+
+## Consequences
+
+### Positive
+
+- Deploy script can use a simple, uniform directory walker:
+  `Card Templates/{note-type}/style.css` + `Card Templates/{note-type}/*-Front.html`
+- No special-casing for subdirectories
+- CSS filename is predictable
+
+### Negative
+
+- Moving files in `Basic - Mandarin/` will show as delete+add in git history
+  (mitigated by `git mv` and a dedicated commit)
+- Anyone with muscle memory for the old paths will need to adjust (low impact —
+  only automated tooling and Claude reference these paths)
+
+## File structure after this ADR is applied
+
+```
+Card Templates/
+  shared/
+    base.css                      # Shared CSS tokens (Story 6)
+    utils.js                      # Shared JS utilities (Story 7)
+  Basic - Mandarin/
+    style.css
+    Reading With Audio - Mandarin -> English - Front.html
+    Reading With Audio - Mandarin -> English - Back.html
+    Listening With Audio - Mandarin -> English - Front.html
+    Listening With Audio - Mandarin -> English - Back.html
+    Recall With Audio - English -> Mandarin - Front.html
+    Recall With Audio - English -> Mandarin - Back.html
+    Reading Without Audio - Mandarin -> English - Front.html
+    Reading Without Audio - Mandarin -> English - Back.html
+    Writing - English -> Mandarin - Front.html
+    Writing - English -> Mandarin - Back.html
+  Basic - Mandarin Grammar/
+    style.css
+    Grammar Quiz - Front.html
+    Grammar Quiz - Back.html
+    Listening With Audio - English -> Mandarin - Front.html
+    Listening With Audio - English -> Mandarin - Back.html
+    Reading With Audio - Mandarin -> English - Front.html
+    Reading With Audio - Mandarin -> English - Back.html
+    Recall Without Audio - English -> Mandarin - Front.html
+    Recall Without Audio - English -> Mandarin - Back.html
+  Basic - Mandarin Sentences/
+    style.css
+    Mandarin - Reading - Front.html
+    Mandarin - Reading - Back.html
+    Mandarin - Recall from definition - Front.html
+    Mandarin - Recall from definition - Back.html
+  Basic - Mandarin From Subtitles/
+    style.css
+    Listening With Audio - English -> Mandarin - Front.html
+    Listening With Audio - English -> Mandarin - Back.html
+    Reading With Audio - Mandarin -> English - Front.html
+    Reading With Audio - Mandarin -> English - Back.html
+    Recall Without Audio - English -> Mandarin - Front.html
+    Recall Without Audio - English -> Mandarin - Back.html
+```

--- a/docs/adr/003-backup-and-safety-strategy.md
+++ b/docs/adr/003-backup-and-safety-strategy.md
@@ -1,0 +1,133 @@
+# ADR-003: Backup and Safety Strategy
+
+## Status
+
+Proposed
+
+## Context
+
+Pushing templates into Anki via AnkiConnect is a write operation against a live
+database containing years of spaced-repetition scheduling data, review history,
+and card content. A bad push could:
+
+- Break card rendering (blank cards, JavaScript errors during review)
+- Corrupt scheduling if a template change somehow triggers re-creation of cards
+- Be difficult to notice immediately (some card types are reviewed infrequently)
+
+AnkiConnect's `updateModelTemplates` and `updateModelStyling` only modify
+template HTML and CSS — they do not touch note fields, scheduling data, or review
+history. But a broken template can still make cards unusable until fixed.
+
+We need a safety strategy that makes every deploy **reversible** and every change
+**inspectable**.
+
+## Decision
+
+### Three layers of protection
+
+#### Layer 1: Pre-deploy template snapshot
+
+Before any write, the deploy script reads the current state of every template and
+CSS it's about to modify via `modelTemplates` and `modelStyling`, and writes them
+to disk:
+
+```
+backups/
+  2026-03-09T14-30-00/
+    Basic - Mandarin/
+      style.css
+      Reading With Audio - Mandarin -> English - Front.html
+      Reading With Audio - Mandarin -> English - Back.html
+      ...
+    Basic - Mandarin Grammar/
+      ...
+```
+
+This is fast (pure API reads), lightweight (just text files), granular (per-
+template), and easy to diff against.
+
+#### Layer 2: Full collection backup via Anki export
+
+Before the **first ever deploy** and periodically thereafter, the user should
+create a full Anki backup via `File > Export > Anki Collection Package (.colpkg)`.
+The deploy script will remind the user to do this if no `.colpkg` backup is
+detected in the `backups/` directory within the last 7 days.
+
+We do not automate `.colpkg` export because:
+- AnkiConnect's `exportPackage` creates `.apkg` per-deck exports, not full
+  collection backups
+- A full collection backup includes scheduling, media, and all note types — the
+  nuclear recovery option
+- Anki also maintains its own automatic backups (configurable in preferences)
+
+#### Layer 3: Restore script
+
+A dedicated restore script reads a backup directory (Layer 1) and pushes the
+saved templates/CSS back into Anki. This provides fast, targeted rollback
+without needing to restore an entire collection.
+
+### Verification protocol
+
+The deploy script will implement a **verify-after-write** step:
+
+1. Push template/CSS via `updateModelTemplates` / `updateModelStyling`
+2. Read it back via `modelTemplates` / `modelStyling`
+3. Compare the read-back content against what was pushed
+4. If mismatch, abort and report
+
+This catches silent failures (e.g. AnkiConnect returning success but not
+actually persisting the change).
+
+### Diff command
+
+A standalone `diff` command compares repo state against live Anki state. This
+serves two purposes:
+
+- **Pre-deploy**: "Here's exactly what will change" — review before committing
+- **Post-deploy**: "Anki now matches the repo" — confidence check
+
+### Fail-fast behaviour
+
+If any API call fails during deploy, the script stops immediately. It does not
+attempt to roll back automatically (partial rollback could make things worse).
+Instead it:
+
+1. Prints which templates were successfully updated
+2. Prints which template failed and the error
+3. Prints the command to restore from the just-created backup
+
+### What the deploy script will NOT do
+
+- **Delete** note types, card templates, or notes — only update existing ones
+- **Trigger AnkiWeb sync** — user syncs manually after visual verification
+- **Modify scheduling data** — templates don't affect scheduling
+- **Run without Anki open** — fails fast with a clear error
+
+## Consequences
+
+### Positive
+
+- Every deploy is reversible within seconds (restore from template snapshot)
+- Full collection backup exists as a nuclear option
+- Changes are inspectable before and after via diff
+- Verify-after-write catches silent failures
+- Fail-fast prevents cascading damage
+
+### Negative
+
+- Backup directory will accumulate over time (mitigated: add a cleanup command
+  or age-based pruning, and `.gitignore` the directory)
+- Pre-deploy backup adds a few seconds to each deploy (acceptable for safety)
+- Restore is not automatic on failure — requires manual intervention. This is
+  intentional: automatic rollback in a partially-applied state could cause more
+  harm than stopping and letting the user decide.
+
+## Appendix: Recovery scenarios
+
+| Scenario | Recovery |
+|----------|----------|
+| Template renders incorrectly after deploy | Run `npm run restore <backup-dir>`, verify in Anki |
+| Deploy failed mid-way (3 of 5 templates updated) | Run `npm run restore <backup-dir>` to restore all to pre-deploy state |
+| Catastrophic issue (scheduling/notes affected) | Restore from `.colpkg` full collection backup via Anki's File > Import |
+| Repo has wrong template names (phantom templates created) | Story 0 name verification prevents this; if it somehow happens, manually delete the phantom template in Anki's Manage Note Types dialog |
+| AnkiConnect not responding | Deploy refuses to start; no changes made |

--- a/docs/adr/004-shared-css-and-js-assembly.md
+++ b/docs/adr/004-shared-css-and-js-assembly.md
@@ -1,0 +1,83 @@
+# ADR-004: Shared CSS and JS Assembly Strategy
+
+## Status
+
+Proposed
+
+## Context
+
+Anki note types each have their own CSS ("Styling") and each card template has
+its own front/back HTML. There is no `@import` or `<script src="">` mechanism
+that works reliably across Anki desktop, AnkiDroid, and AnkiMobile. Each
+template must be fully self-contained.
+
+Currently the four note types duplicate ~80% of their CSS (variables, night mode,
+Material Icons, base typography, spacing, sidebar styles) and ~60% of their JS
+(pinyin decoding, tone coloring, font rotation, character detection). These
+duplicates have drifted apart.
+
+We need a way to maintain shared code in one place while producing self-contained
+output for each Anki template.
+
+## Decision
+
+### Build-time assembly (not copy-paste)
+
+Shared code lives in `Card Templates/shared/`:
+
+```
+Card Templates/shared/
+  base.css       # CSS variables, night mode, Material Icons, base typography
+  utils.js       # decodePinyin, recolorCharacters, assignClassBasedOnTime, etc.
+```
+
+The **deploy script** handles assembly at push time:
+
+- **CSS**: Reads `shared/base.css`, appends the note type's `style.css`, and
+  pushes the concatenated result via `updateModelStyling`.
+- **JS**: Reads `shared/utils.js` and injects it into each template's HTML at a
+  marked insertion point (`<!-- SHARED_JS -->`) before pushing via
+  `updateModelTemplates`.
+
+No intermediate files are written to disk. Assembly happens in memory during
+deploy. The repo files remain clean and un-duplicated.
+
+### Why not `@import` or external CSS?
+
+Anki's `@import url("_file.css")` feature (referencing files in the media folder)
+works for CSS but:
+- Anki doesn't detect edits to existing media files for sync
+- Doesn't work for JS at all
+- Requires manual media file management outside the repo
+- Different behaviour across Anki desktop, AnkiDroid, and AnkiMobile
+
+### Why not a pre-commit build step that writes assembled files?
+
+- Would duplicate every file (source + assembled), causing confusion about which
+  to edit
+- PurgeCSS already exists as a build step for CSS; adding another layer of
+  assembly increases complexity
+- The deploy script is the single place where repo -> Anki translation happens;
+  assembly belongs there
+
+## Consequences
+
+### Positive
+
+- Single source of truth for shared CSS and JS
+- No drift between note types for common code
+- Template-specific files contain only template-specific code
+- No build artifacts in the repo
+- Easy to diff: changes to `shared/base.css` are clearly about shared
+  styling; changes to `Basic - Mandarin/style.css` are clearly about that
+  note type
+
+### Negative
+
+- What you see in the repo is not exactly what Anki receives (shared code is
+  injected at deploy time). Mitigated by the `diff` command which shows the
+  assembled output vs what's in Anki.
+- Editing shared code requires a deploy to test in Anki (no live preview).
+  Same as the current workflow, just more explicit.
+- Template HTML files need a `<!-- SHARED_JS -->` marker, which is slightly
+  unusual. But it's self-documenting and grep-able.

--- a/docs/adr/005-visual-design-for-learning.md
+++ b/docs/adr/005-visual-design-for-learning.md
@@ -1,0 +1,119 @@
+# ADR-005: Visual Design Principles for Learning Optimisation
+
+## Status
+
+Proposed
+
+## Context
+
+The four note types have evolved independently. They share ~80% of their CSS via
+copy-paste but have drifted in specifics: font sizes, spacing, colour usage, and
+visual hierarchy vary between them. The templates work, but they haven't been
+systematically audited against what research says about effective flashcard
+design.
+
+Flashcard visual design directly impacts learning outcomes:
+
+- **Cognitive load**: Cluttered cards slow processing and reduce retention
+  ([Mayer's Coherence Principle](https://www.learningscientists.org/blog/2017/7/28-1))
+- **Visual hierarchy**: The tested element must be the first thing the eye lands
+  on — if it isn't, the brain processes distractors first and primes the wrong
+  retrieval pathways
+- **Typography**: CJK characters need enough size for stroke detail (critical for
+  Writing cards); pinyin needs to be legible but must not dominate
+- **Colour coding**: Tone colours are a learning aid, not decoration — they need
+  to be perceptually distinct under all viewing conditions
+- **Review speed**: Animations and transitions that add even 200ms per card
+  compound across thousands of reviews
+
+## Decision
+
+### Guiding principles (in priority order)
+
+1. **Test stimulus dominance** — The element being tested (character, sentence,
+   meaning, audio cue) must have overwhelming visual priority. Everything else is
+   secondary.
+
+2. **Minimal viable chrome** — UI elements (buttons, sidebars, metadata) should
+   be present but visually quiet. If removing an element doesn't hurt the review
+   task, remove it. If it's needed sometimes but not always, hide it behind
+   interaction (tap to reveal).
+
+3. **Consistent rhythm** — Same spacing scale, same font sizes for the same
+   semantic roles, across all note types. A "character" looks the same size
+   whether it's on a Reading card or a Writing card.
+
+4. **Perceptual distinctness** — Tone colours must be distinguishable from each
+   other and from the background in day mode, night mode, and with common colour
+   vision deficiencies (protanopia, deuteranopia). This may mean adjusting hue,
+   not just lightness.
+
+5. **Speed** — No animation that delays content visibility. Transitions are for
+   user-initiated actions (e.g. sidebar open), not for card rendering.
+
+6. **Night mode as first-class** — Not an afterthought. Night mode must be tested
+   with the same rigour as day mode, meeting WCAG AA contrast ratios.
+
+### What this does NOT cover
+
+- Card *content* (which fields to show, what data to populate) — that's a note
+  type design question, not a visual design question
+- HanziWriter configuration (stroke order animation speed, hint behaviour) —
+  that's functional behaviour, covered separately
+- Anki's own UI (reviewer buttons, menu bar) — we can't control that
+
+### Implementation approach
+
+Changes are made as small, independently deployable increments (Story 8a-8g in
+the epic). Each increment:
+
+1. Is deployed via the deploy script (Story 3)
+2. Is verified via before/after diff (Story 4)
+3. Is tested during at least one real study session
+4. Can be rolled back independently via the restore script (Story 2)
+
+No "big bang" visual redesign. Each change earns its place by surviving real
+usage.
+
+## Consequences
+
+### Positive
+
+- Cards become more effective learning tools, not just functional ones
+- Consistent visual language across note types reduces cognitive switching cost
+  when reviewing mixed decks
+- Night mode becomes properly usable (important for evening study sessions)
+- Tone colours become a reliable learning signal rather than approximate
+  decoration
+
+### Negative
+
+- Visual changes are subjective — what feels "cleaner" to one person may feel
+  "too sparse" to another. Mitigated by incremental deployment and rollback
+  capability.
+- Some visual changes may temporarily disrupt muscle memory (e.g. "the hint
+  button used to be here"). Mitigated by making changes small and giving time to
+  adapt between increments.
+- Contrast ratio compliance may force tone colour changes that look different
+  from what the user is accustomed to. Mitigated by testing with real cards
+  before committing.
+
+## Current state (for reference)
+
+### Shared across all four note types
+- 5 tone colours: Red #f44336, Orange #ff9800, Green #4caf50, Blue #2196f3,
+  Gray #607d8b
+- Night mode: #1f1f1f background, rgb(240,240,240) text
+- Base font: 20px Arial
+- Material Icons for action buttons
+- Spacing tokens: xxs (0.25rem) through xxl (6rem)
+- Platform-specific CJK fonts: KaiTi (macOS/iOS), AR PL KaitiM GB (Linux)
+
+### Per-note-type differences that need reconciling
+| Aspect | Basic - Mandarin | Grammar | Sentences | From Subtitles |
+|--------|-----------------|---------|-----------|----------------|
+| Complexity | Highest (sidebar, forms, fieldsets) | Medium (quiz buttons) | Low (textarea, buttons) | Low (simplified Mandarin) |
+| Character size | 3em / 30-40px | 40px | 2.2rem | 3em |
+| Button style | Material icon buttons | 3D raised buttons + quiz buttons | 3D raised buttons | Material icon buttons |
+| Layout | Grid + sidebar | Grid + flexbox | Grid + flexbox | Grid + flexbox |
+| Unique elements | Sidebar nav, custom checkboxes, fieldsets | btn-q/btn-a quiz pattern | Textarea input | Lesson info |

--- a/docs/epic-template-deploy-pipeline.md
+++ b/docs/epic-template-deploy-pipeline.md
@@ -1,0 +1,199 @@
+# Epic: Automated Template Deploy Pipeline
+
+## Motivation
+
+Card templates are maintained as HTML/CSS files in this repo but must be manually
+copy-pasted into Anki's template editor. This is error-prone and has led to
+drift between the repo and what Anki actually runs. A deploy script would let us
+push changes from the repo into Anki with a single command, and — critically —
+would make the design-language normalisation work (Phase 2) safe to iterate on.
+
+The stakes are high: a bad template push could corrupt card rendering across
+thousands of review cards, directly impacting Chinese study. This epic therefore
+treats **safety and reversibility** as first-class concerns.
+
+---
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Note type** (Anki calls this "model") | A schema — defines fields and card templates. e.g. "Basic - Mandarin" |
+| **Card template** | A front/back HTML pair within a note type. e.g. "Writing - English -> Mandarin" |
+| **Styling** | The single CSS block shared by all card templates in a note type |
+
+A note type has **one CSS** and **one or more card templates** (each with a front
+and back).
+
+---
+
+## Current Repo-to-Anki Mapping
+
+```
+Card Templates/
+  {Note Type}/
+    style.css (or styles.css)   -->  Note type CSS ("Styling")
+    {optional subdirectory}/
+      {Card Template Name} - Front.html  -->  Card template qfmt
+      {Card Template Name} - Back.html   -->  Card template afmt
+```
+
+### Concrete mapping
+
+| Repo directory | Anki note type | Card templates |
+|---|---|---|
+| `Basic - Mandarin/` | Basic - Mandarin | Reading With Audio - Mandarin -> English, Listening With Audio - Mandarin -> English, Recall With Audio - English -> Mandarin, Reading Without Audio - Mandarin -> English, Writing - English -> Mandarin |
+| `Basic - Mandarin Grammar/` | Basic - Mandarin Grammar | Grammar Quiz, Listening With Audio - English -> Mandarin, Reading With Audio - Mandarin -> English, Recall Without Audio - English -> Mandarin |
+| `Basic - Mandarin Sentences/` | Basic - Mandarin Sentences | Mandarin - Reading, Mandarin - Recall from definition |
+| `Basic - Mandarin From Subtitles/` | Basic - Mandarin From Subtitles | Listening With Audio - English -> Mandarin, Reading With Audio - Mandarin -> English, Recall Without Audio - English -> Mandarin |
+
+**Important**: The card template name in Anki must match the filename prefix
+exactly (everything before ` - Front.html` / ` - Back.html`). The deploy script
+must verify this before pushing, not assume it.
+
+---
+
+## Stories
+
+### Story 0: Verify repo-to-Anki name mapping
+
+**Before any automated pushing**, we need to confirm that the filenames in this
+repo exactly match the card template names in Anki. A mismatch could create
+duplicate templates or silently fail to update the right one.
+
+**Acceptance criteria:**
+- [ ] Script connects to AnkiConnect and calls `modelNames` to list all note types
+- [ ] For each note type, calls `modelTemplates` to get actual card template names
+- [ ] Compares against the repo file tree and reports:
+  - Exact matches
+  - Templates in Anki but missing from repo (warning — may be intentional)
+  - Templates in repo but missing from Anki (error — filename probably wrong)
+- [ ] Any mismatches are corrected (rename files in repo to match Anki, or vice
+  versa if the Anki name is wrong)
+- [ ] Output is saved as a mapping file (`scripts/template-mapping.json`) that
+  the deploy script will consume
+
+### Story 1: Backup before deploy
+
+**Every deploy must create a full backup of the current Anki state first.**
+
+**Acceptance criteria:**
+- [ ] Script calls `exportPackage` via AnkiConnect to create a timestamped
+  `.apkg` file in a `backups/` directory (gitignored)
+- [ ] Alternatively, if `exportPackage` is unavailable, script reads all
+  templates and CSS via `modelTemplates` + `modelStyling` and writes them to
+  a timestamped directory under `backups/` as plain files
+- [ ] Backup includes every note type that will be modified
+- [ ] Script verifies backup is non-empty and readable before proceeding
+- [ ] `backups/` is added to `.gitignore`
+
+### Story 2: Backup restore and verification
+
+**We must be able to restore from backup before we trust the deploy.**
+
+**Acceptance criteria:**
+- [ ] `npm run restore` (or `node scripts/restore.js <backup-dir>`) reads a
+  backup directory and pushes all templates/CSS back via AnkiConnect
+- [ ] Restore script has a `--dry-run` flag that shows what it would do
+- [ ] Integration test: backup -> make a trivial change -> deploy -> restore ->
+  verify templates match the backup exactly
+- [ ] Documented in README
+
+### Story 3: Deploy script
+
+**Acceptance criteria:**
+- [ ] `npm run deploy` (or `node scripts/deploy.js`) pushes all templates and
+  CSS from the repo into Anki via AnkiConnect
+- [ ] Reads `scripts/template-mapping.json` to know which repo files map to
+  which Anki note types and card templates
+- [ ] Calls `updateModelStyling` for each note type's CSS
+- [ ] Calls `updateModelTemplates` for each card template's front/back HTML
+- [ ] Has a `--dry-run` flag that shows what would be pushed without pushing
+- [ ] Has a `--note-type <name>` flag to deploy only one note type
+- [ ] Automatically runs Story 1 backup before any writes (can be skipped with
+  `--no-backup` for speed during iteration)
+- [ ] Reports success/failure per template
+- [ ] On any failure, stops immediately (does not continue pushing remaining
+  templates) and prints restore instructions
+
+### Story 4: Diff / preview command
+
+**Acceptance criteria:**
+- [ ] `npm run diff` (or `node scripts/diff.js`) compares repo templates against
+  what's currently in Anki
+- [ ] Shows a unified diff for each template and CSS
+- [ ] Useful for verifying state before and after deploy
+- [ ] Can be used as a pre-deploy check: "nothing unexpected will change"
+
+### Story 5: Normalise repo file naming conventions
+
+**Acceptance criteria:**
+- [ ] CSS files consistently named `style.css` (singular) across all note types
+- [ ] Subdirectory structure decision made (see ADR-002) and applied
+- [ ] All filenames validated against Anki's actual template names (Story 0)
+
+### Story 6: Normalise shared CSS
+
+**Acceptance criteria:**
+- [ ] Shared CSS tokens, night mode, Material Icons, base typography extracted to
+  `Card Templates/shared/base.css`
+- [ ] Deploy script concatenates `base.css` + note-type-specific `style.css`
+  before pushing to Anki
+- [ ] Each note type's `style.css` contains only overrides
+- [ ] Visual rendering in Anki is identical before and after (verified via Story 4
+  diff showing only whitespace/ordering changes in final output)
+
+### Story 7: Normalise shared JavaScript
+
+**Acceptance criteria:**
+- [ ] Shared JS utilities (`decodePinyin`, `recolorCharacters`,
+  `assignClassBasedOnTime`, `isChineseCharacter`, LTR cleanup) extracted to
+  `Card Templates/shared/utils.js`
+- [ ] Deploy script (or build step) injects shared JS into each template's
+  `<script>` block before pushing
+- [ ] Card behaviour is identical before and after
+
+---
+
+## Story dependency graph
+
+```
+Story 0 (verify mapping)
+  |
+  v
+Story 1 (backup) ---> Story 2 (restore + verify)
+  |
+  v
+Story 3 (deploy) ---> Story 4 (diff)
+  |
+  v
+Story 5 (normalise filenames)
+  |
+  v
+Story 6 (normalise CSS) + Story 7 (normalise JS)   [parallel]
+```
+
+---
+
+## Safety guardrails
+
+1. **Pre-deploy backup** — automatic, cannot be skipped without explicit flag
+2. **Tested restore** — restore script is written and tested before deploy script
+   is considered complete
+3. **Dry-run everything** — every write operation has a dry-run mode
+4. **Diff before and after** — `npm run diff` to inspect exactly what changed
+5. **Name verification** — deploy refuses to run if repo filenames don't match
+   Anki's actual template names (prevents creating phantom templates)
+6. **Atomic-ish deploys** — fail fast on first error, print restore instructions
+7. **No destructive Anki operations** — script only updates existing templates
+   and CSS, never deletes note types, card templates, or notes
+8. **Manual Anki sync** — script does NOT trigger AnkiWeb sync; user syncs
+   manually after verifying cards look correct
+
+---
+
+## Prerequisites
+
+- Anki desktop running with [AnkiConnect](https://ankiweb.net/shared/info/2055492159)
+  add-on installed (localhost:8765)
+- Node.js (already present for existing lint/format/purgecss tooling)

--- a/docs/epic-template-deploy-pipeline.md
+++ b/docs/epic-template-deploy-pipeline.md
@@ -55,23 +55,41 @@ must verify this before pushing, not assume it.
 
 ## Stories
 
-### Story 0: Verify repo-to-Anki name mapping
+### Story 0: Discover and verify all Anki templates
 
-**Before any automated pushing**, we need to confirm that the filenames in this
-repo exactly match the card template names in Anki. A mismatch could create
-duplicate templates or silently fail to update the right one.
+**Before any automated pushing**, we need a complete picture of what exists in
+Anki and how it maps (or doesn't map) to the repo. This is the foundation for
+everything else.
 
 **Acceptance criteria:**
-- [ ] Script connects to AnkiConnect and calls `modelNames` to list all note types
+- [ ] Script connects to AnkiConnect and calls `modelNames` to list **all** note
+  types in the collection — not just the four we expect
 - [ ] For each note type, calls `modelTemplates` to get actual card template names
-- [ ] Compares against the repo file tree and reports:
-  - Exact matches
-  - Templates in Anki but missing from repo (warning — may be intentional)
-  - Templates in repo but missing from Anki (error — filename probably wrong)
-- [ ] Any mismatches are corrected (rename files in repo to match Anki, or vice
-  versa if the Anki name is wrong)
+  and `modelFieldNames` to get fields
+- [ ] Produces a full inventory report with three sections:
+  1. **Matched**: Note types/templates that exist in both Anki and the repo, with
+     exact filename-to-template-name correspondence
+  2. **In Anki, not in repo**: Note types or individual card templates that exist
+     in Anki but have no corresponding files in the repo. For each, report:
+     - Note type name
+     - Card template names
+     - Number of notes using this note type (via `findNotes`)
+     - Whether it appears to be a built-in/default type or a custom type
+  3. **In repo, not in Anki**: Files in the repo that don't match any Anki
+     template (error — filename probably wrong, or note type was deleted)
+- [ ] "In Anki, not in repo" items get triaged:
+  - **Adopt**: Pull the template from Anki into the repo (bring under version
+    control)
+  - **Ignore**: Known third-party note type, add to an ignore list
+    (`scripts/ignored-note-types.json`)
+  - **Orphan**: Note type with zero notes — candidate for deletion (manual, not
+    automated)
+- [ ] Any name mismatches in matched types are corrected (rename files in repo to
+  match Anki, or vice versa if the Anki name is wrong)
 - [ ] Output is saved as a mapping file (`scripts/template-mapping.json`) that
   the deploy script will consume
+- [ ] Inventory report is saved to `docs/anki-template-inventory.md` for
+  reference
 
 ### Story 1: Backup before deploy
 
@@ -153,12 +171,53 @@ duplicate templates or silently fail to update the right one.
   `<script>` block before pushing
 - [ ] Card behaviour is identical before and after
 
+### Story 8: Visual design audit and optimisation for learning
+
+**Improve card visual design based on SRS and language-learning research.** See
+ADR-005 for rationale and principles.
+
+**This story is intentionally broken into small, independently deployable
+increments** — each sub-task can be deployed, reviewed during real study sessions,
+and rolled back if it hurts rather than helps.
+
+**Acceptance criteria:**
+- [ ] **8a: Typography audit** — Review and optimise font sizing, line height,
+  and character spacing for readability. CJK characters should be large enough for
+  stroke detail; pinyin should be legible but secondary. Verify on both desktop
+  and AnkiDroid. Document chosen sizes and rationale.
+- [ ] **8b: Visual hierarchy** — Ensure the most important element on each card
+  (the thing being tested) has clear visual dominance. Secondary information
+  (pinyin, meaning, example sentences) should be visually subordinate. The user's
+  eye should land on the test stimulus immediately.
+- [ ] **8c: Night mode parity** — Verify night mode provides equivalent
+  readability to day mode. Current night mode overrides all exist but haven't
+  been audited for contrast ratios. All text must meet WCAG AA contrast (4.5:1
+  for body text, 3:1 for large text).
+- [ ] **8d: Reduce visual clutter** — Identify and remove or de-emphasise UI
+  elements that distract from the core study loop. Sidebars, buttons, and
+  metadata should not compete with the test stimulus. Less is more during review.
+- [ ] **8e: Tone colour refinement** — Audit the five tone colours for
+  distinctness under both day and night mode. Current colours are Material Design
+  defaults; they may not be optimal for distinguishing tones at a glance,
+  especially red (tone 1) vs orange (tone 2) for colour-deficient users.
+- [ ] **8f: Consistent spacing and rhythm** — Apply a consistent spacing scale
+  across all four note types. Current spacing tokens (xxs through xxl) are defined
+  but applied inconsistently between templates.
+- [ ] **8g: Animation and transition review** — Remove or simplify animations
+  that add latency to the review loop. Card transitions should feel instant. Any
+  animation that delays seeing content hurts review speed.
+
+**Verification for each sub-task:**
+- Before/after screenshots (desktop + mobile)
+- Side-by-side comparison reviewed during at least one real study session
+- Can be rolled back independently via restore script
+
 ---
 
 ## Story dependency graph
 
 ```
-Story 0 (verify mapping)
+Story 0 (discover + verify ALL templates)
   |
   v
 Story 1 (backup) ---> Story 2 (restore + verify)
@@ -171,6 +230,9 @@ Story 5 (normalise filenames)
   |
   v
 Story 6 (normalise CSS) + Story 7 (normalise JS)   [parallel]
+  |
+  v
+Story 8a-8g (visual optimisation)  [sequential sub-tasks, each independently deployable]
 ```
 
 ---


### PR DESCRIPTION
Each hint press now increments the mistake counter and updates the
rating indicator. The first 1-2 hints per character use the same
stroke-weighted penalty as a regular drawing mistake (1/(strokeNum+1)).
After 2 hints, each additional press adds a full 1.0 penalty to the
weighted score.

https://claude.ai/code/session_01JyPKpnze7YwFdzFcN4FXXL